### PR TITLE
fix(test): IO safety violations while dropping the fd of open file

### DIFF
--- a/tests/test_close_fds.rs
+++ b/tests/test_close_fds.rs
@@ -55,15 +55,14 @@ fn run_basic_test(
     ),
     builder: close_fds::CloseFdsBuilder,
 ) {
-    let f1 = std::fs::File::open("/").unwrap();
-    let f2 = std::fs::File::open("/").unwrap();
-    let f3 = std::fs::File::open("/").unwrap();
 
-    let fd1 = f1.as_raw_fd();
-    let fd2 = f2.as_raw_fd();
-    let fd3 = f3.as_raw_fd();
+    let path = std::ffi::CString::new("/").unwrap();
 
-    drop(f3);
+    let fd1 = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY) };
+    let fd2 = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY) };
+    let fd3 = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY) };
+
+    unsafe { libc::close(fd3) };
 
     assert!(is_fd_open(fd1));
     assert!(is_fd_open(fd2));


### PR DESCRIPTION
With stdlib changes `File` now uses `OwnedFd` internally that does IO safety checks in debug mode and that consequently causes the test here to panic as FDs of open files are closed  behind stdlib's back. So this patch uses the low level `libc::open` to directly return a `RawFd`, skipping the `std::fs::File::open` calls and `as_raw_fd` conversion.

Fixes: #1 